### PR TITLE
Added count method to SharedRc

### DIFF
--- a/src/shared_rc.rs
+++ b/src/shared_rc.rs
@@ -39,6 +39,10 @@ impl<T: SharedMemCast> SharedRc<T> {
     pub fn address(&self) -> SharedAddressRange {
         self.0.address()
     }
+
+    pub fn count(this: &Self) -> usize {
+        this.0.ref_count.load(Ordering::SeqCst)
+    }
 }
 
 impl<T: SharedMemCast> TryFrom<SharedAddressRange> for SharedRc<T> {


### PR DESCRIPTION
This allows the user to retrieve the current reference count.