### PR TITLE
Reexport SharedMemCast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ mod shmem_name;
 // All unsafe code lives here
 mod unsafe_code;
 
+// Reexport traits.
+pub use shared_memory::SharedMemCast;
+
 pub use allocator::get_bootstrap_name;
 pub use allocator::set_bootstrap_name;
 pub use shared_address_range::SharedAddressRange;


### PR DESCRIPTION
This is usefull for a user that need to put a `SharedMemCast`
trait bound without having to explicitely depend on `shared_memory`. Otherwise the user would have to manually look up the version of `shared_memory` that is depended upon.